### PR TITLE
Optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:alpine AS builder
 
-# Set necessary environmet variables needed for our image
+# Set necessary environment variables needed for our image
 ENV GO111MODULE=on \
     CGO_ENABLED=0 \
     GOOS=linux \
@@ -24,7 +24,7 @@ RUN go build -o vedran .
 WORKDIR /dist
 
 # Copy binary from build to main folder
-RUN cp /build/vedran .
+RUN cp /build .
 
 # Build a small image
 FROM scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,35 @@
-FROM golang:alpine
+FROM golang:alpine AS builder
 
-RUN mkdir /app
-ADD . /app/
-WORKDIR /app
+# Set necessary environmet variables needed for our image
+ENV GO111MODULE=on \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64
 
-RUN apk add make
+# Move to working directory /build
+WORKDIR /build
 
-RUN make build
+# Copy and download dependency using go mod
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
 
-CMD ["./vedran"]
+# Copy the code into the container
+COPY . .
+
+# Build the application
+RUN go build -o vedran .
+
+# Move to /dist directory as the place for resulting binary folder
+WORKDIR /dist
+
+# Copy binary from build to main folder
+RUN cp /build/vedran .
+
+# Build a small image
+FROM scratch
+
+COPY --from=builder /dist/vedran /
+
+# Command to run
+ENTRYPOINT ["/vedran"]


### PR DESCRIPTION
Optimize Dockerfile PR:
- replaced make commands with native go commands
- final image only contains binary (uses `scratch` image as a starting point)

closes #13 