### PR TITLE
Fix tunnel server address init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fix
 - Fix panic if no nodes in database after startup [\#62](https://github.com/NodeFactoryIo/vedran/pull/62) ([mpetrun5](https://github.com/mpetrun5))
+- Fix error on provided public IP [\#72](https://github.com/NodeFactoryIo/vedran/pull/72) ([MakMuftic](https://github.com/MakMuftic))
 
 ### Changed
 - Use port from tunnel map for calling node [\#65](https://github.com/NodeFactoryIo/vedran/pull/65) ([mpetrun5](https://github.com/mpetrun5))

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -175,6 +175,8 @@ func startCommand(_ *cobra.Command, _ []string) {
 		}
 		tunnelServerAddress = fmt.Sprintf("%s:%s", IP.String(), tunnelServerPort)
 		log.Infof("Tunnel server will listen on %s and connect tunnels on port range %s", tunnelServerAddress, tunnelPortRange)
+	} else {
+		tunnelServerAddress = fmt.Sprintf("%s:%s", publicIP, tunnelServerPort)
 	}
 
 	tunnel.StartHttpTunnelServer(tunnelServerPort, pPool)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide all required information
-->

**Fix bug where tunnel server address wasn't being initialized if the public is provided as flag `public-ip`**

### PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have run linter localy
- [x] I have run unit and integration tests locally
- [x] Rebased to master branch / merged master
- [x] Updated CHANGELOG.md

### Issues
<!-- Use github keyword to close issues that are related to this PR -->

<!-- [REQUIRED] -->
Closes #71 
