### PR TITLE
Fix register handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fix
 - Fix panic if no nodes in database after startup [\#62](https://github.com/NodeFactoryIo/vedran/pull/62) ([mpetrun5](https://github.com/mpetrun5))
 - Fix error on provided public IP [\#72](https://github.com/NodeFactoryIo/vedran/pull/72) ([MakMuftic](https://github.com/MakMuftic))
+- Fix register handler [\#83](https://github.com/NodeFactoryIo/vedran/pull/83) ([MakMuftic](https://github.com/MakMuftic))
 
 ### Changed
 - Use port from tunnel map for calling node [\#65](https://github.com/NodeFactoryIo/vedran/pull/65) ([mpetrun5](https://github.com/mpetrun5))

--- a/internal/controllers/register.go
+++ b/internal/controllers/register.go
@@ -49,37 +49,46 @@ func (c ApiController) RegisterHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-
-	// generate auth token
-	token, err := auth.CreateNewToken(registerRequest.Id)
+	// look if node already registered
+	node, err := c.repositories.NodeRepo.FindByID(registerRequest.Id)
 	if err != nil {
-		// unknown error
-		log.Errorf("Unable to create auth token, error: %v", err)
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		return
+		// node not registered
+		if err.Error() == "not found" {
+			// generate auth token
+			token, err := auth.CreateNewToken(registerRequest.Id)
+			if err != nil {
+				// unknown error
+				log.Errorf("Unable to create auth token, error: %v", err)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
+			}
+
+			// save node to database
+			node = &models.Node{
+				ID:            registerRequest.Id,
+				ConfigHash:    registerRequest.ConfigHash,
+				PayoutAddress: registerRequest.PayoutAddress,
+				Token:         token,
+				LastUsed:      time.Now().Unix(),
+			}
+			err = c.repositories.NodeRepo.Save(node)
+			if err != nil {
+				log.Errorf("Unable to save node %v to database, error: %v", node, err)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
+			}
+
+			log.Infof("New node %s registered", node.ID)
+		} else {
+			log.Errorf("Unable to check if node %s already created, error: %v", node.ID, err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		}
 	}
 
-	// save node to database
-	node := &models.Node{
-		ID:            registerRequest.Id,
-		ConfigHash:    registerRequest.ConfigHash,
-		PayoutAddress: registerRequest.PayoutAddress,
-		Token:         token,
-		LastUsed:      time.Now().Unix(),
-	}
-	err = c.repositories.NodeRepo.Save(node)
-	if err != nil {
-		log.Errorf("Unable to save node %v to database, error: %v", node, err)
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		return
-	}
-
-	log.Infof("New node %s registered", node.ID)
-
-	// return generated token
+	// return token
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(RegisterResponse{
-		Token:               token,
+		Token:               node.Token,
 		TunnelServerAddress: configuration.Config.TunnelServerAddress,
 	})
 }

--- a/internal/repositories/node.go
+++ b/internal/repositories/node.go
@@ -63,9 +63,9 @@ func (r *nodeRepo) InitNodeRepo() error {
 }
 
 func (r *nodeRepo) FindByID(ID string) (*models.Node, error) {
-	var node *models.Node
-	err := r.db.One("ID", ID, node)
-	return node, err
+	var node models.Node
+	err := r.db.One("ID", ID, &node)
+	return &node, err
 }
 
 func (r *nodeRepo) Save(node *models.Node) error {
@@ -194,4 +194,3 @@ func (r *nodeRepo) ResetNodeCooldown(ID string) (*models.Node, error) {
 	err = r.db.Save(node)
 	return node, err
 }
-


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide all required information
-->

**Refactor registration handler so if a node with a provided ID already registered only register response with the token is returned**
<!-- e.g. Refactored auth logic as part of the transition to OAuth -->

### PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have run linter localy
- [x] I have run unit and integration tests locally
- [x] Rebased to master branch / merged master
- [x] Updated CHANGELOG.md

### Changes
<!-- Please describe all changes made to codebase. -->
- Restructure register handler function
- Fix failing tests and expand to cover problematic use case

<!-- ### Example -->
<!-- You can add screenshots or videos to show changed behaviour -->

### Issues
<!-- Use github keyword to close issues that are related to this PR -->

<!-- [REQUIRED] -->
Closes #79 
