### PR TITLE
Refactor how nodes are added to active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Changed
 - Use port from tunnel map for calling node [\#65](https://github.com/NodeFactoryIo/vedran/pull/65) ([mpetrun5](https://github.com/mpetrun5))
 - Refactor whitelisting [\#75](https://github.com/NodeFactoryIo/vedran/pull/75) ([MakMuftic](https://github.com/MakMuftic))
+- Refactor how nodes are added to active [\#85](https://github.com/NodeFactoryIo/vedran/pull/85) ([MakMuftic](https://github.com/MakMuftic))
 
 ## [v0.1.1]((https://github.com/NodeFactoryIo/vedran/tree/v0.1.1))
 

--- a/internal/controllers/metrics_test.go
+++ b/internal/controllers/metrics_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/NodeFactoryIo/vedran/internal/repositories"
 	mocks "github.com/NodeFactoryIo/vedran/mocks/repositories"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -21,40 +22,144 @@ func TestApiController_SaveMetricsHandler(t *testing.T) {
 	tests := []struct {
 		name                  string
 		metricsRequest        interface{}
+		nodeId                string
 		httpStatus            int
-		repoReturn            interface{}
-		numberOfRepoSaveCalls int
+		// NodeRepo.FindByID
+		nodeRepoFindByIDReturns *models.Node
+		nodeRepoFindByIDError   error
+		nodeRepoFindByIDNumOfCalls int
+		// NodeRepo.AddNodeToActive
+		nodeRepoAddNodeToActiveError error
+		nodeRepoAddNodeToActiveNumOfCalls int
+		// MetricsRepo.FindByID
+		metricsRepoFindByIDError error
+		metricsRepoFindByIDNumOfCalls int
+		// MetricsRepo.Save
+		metricsRepoSaveError error
+		metricsRepoSaveNumOfCalls int
 	}{
 		{
-			name: "Valid metrics save request",
+			name: "Valid metrics save request, older metrics entry already saved",
 			metricsRequest: MetricsRequest{
 				PeerCount:             10,
 				BestBlockHeight:       100,
 				FinalizedBlockHeight:  100,
 				ReadyTransactionCount: 10,
 			},
-			httpStatus:            http.StatusOK,
-			repoReturn:            nil,
-			numberOfRepoSaveCalls: 1,
+			nodeId:                            "1",
+			httpStatus:                        http.StatusOK,
+			nodeRepoFindByIDReturns:           &models.Node{
+				ID: "1",
+			},
+			nodeRepoFindByIDError:             nil,
+			nodeRepoFindByIDNumOfCalls:        1,
+			nodeRepoAddNodeToActiveError:      nil,
+			nodeRepoAddNodeToActiveNumOfCalls: 0,
+			metricsRepoFindByIDError:          nil,
+			metricsRepoFindByIDNumOfCalls:     1,
+			metricsRepoSaveError:              nil,
+			metricsRepoSaveNumOfCalls:         1,
 		},
 		{
-			name:                  "Invalid metrics save request",
-			metricsRequest:        struct{ PeerCount string }{PeerCount: "10"},
-			httpStatus:            http.StatusBadRequest,
-			repoReturn:            nil,
-			numberOfRepoSaveCalls: 0,
-		},
-		{
-			name: "Database fails on save",
+			name: "Valid metrics save request, first metrics entry, node should be added to active",
 			metricsRequest: MetricsRequest{
 				PeerCount:             10,
 				BestBlockHeight:       100,
 				FinalizedBlockHeight:  100,
 				ReadyTransactionCount: 10,
 			},
+			nodeId:                            "1",
+			httpStatus:                        http.StatusOK,
+			nodeRepoFindByIDReturns:           &models.Node{
+				ID: "1",
+			},
+			nodeRepoFindByIDError:             nil,
+			nodeRepoFindByIDNumOfCalls:        1,
+			nodeRepoAddNodeToActiveError:      nil,
+			nodeRepoAddNodeToActiveNumOfCalls: 1,
+			metricsRepoFindByIDError:          errors.New("not found"),
+			metricsRepoFindByIDNumOfCalls:     1,
+			metricsRepoSaveError:              nil,
+			metricsRepoSaveNumOfCalls:         1,
+		},
+		{
+			name:                              "Invalid metrics save request",
+			metricsRequest:                    struct{ PeerCount string }{PeerCount: "10"},
+			nodeId:                            "1",
+			httpStatus:                        http.StatusBadRequest,
+		},
+		{
+			name: "Database fails on fetching node",
+			metricsRequest: MetricsRequest{
+				PeerCount:             10,
+				BestBlockHeight:       100,
+				FinalizedBlockHeight:  100,
+				ReadyTransactionCount: 10,
+			},
+			nodeId: "1",
 			httpStatus:            http.StatusInternalServerError,
-			repoReturn:            errors.New("database error"),
-			numberOfRepoSaveCalls: 1,
+			nodeRepoFindByIDError:             errors.New("db error"),
+			nodeRepoFindByIDNumOfCalls:        1,
+		},
+		{
+			name: "Database fails on fetching metrics",
+			metricsRequest: MetricsRequest{
+				PeerCount:             10,
+				BestBlockHeight:       100,
+				FinalizedBlockHeight:  100,
+				ReadyTransactionCount: 10,
+			},
+			nodeId: "1",
+			httpStatus:            http.StatusInternalServerError,
+			nodeRepoFindByIDError:             nil,
+			nodeRepoFindByIDReturns: &models.Node{
+				ID: "1",
+			},
+			nodeRepoFindByIDNumOfCalls:        1,
+			metricsRepoFindByIDError:          errors.New("db error"),
+			metricsRepoFindByIDNumOfCalls:     1,
+		},
+		{
+			name: "Database fails on saving metrics",
+			metricsRequest: MetricsRequest{
+				PeerCount:             10,
+				BestBlockHeight:       100,
+				FinalizedBlockHeight:  100,
+				ReadyTransactionCount: 10,
+			},
+			nodeId: "1",
+			httpStatus:            http.StatusInternalServerError,
+			nodeRepoFindByIDError:             nil,
+			nodeRepoFindByIDReturns: &models.Node{
+				ID: "1",
+			},
+			nodeRepoFindByIDNumOfCalls:        1,
+			metricsRepoFindByIDError:          nil,
+			metricsRepoFindByIDNumOfCalls:     1,
+			metricsRepoSaveError: errors.New("db error"),
+			metricsRepoSaveNumOfCalls: 1,
+		},
+		{
+			name: "Adding node to active fails",
+			metricsRequest: MetricsRequest{
+				PeerCount:             10,
+				BestBlockHeight:       100,
+				FinalizedBlockHeight:  100,
+				ReadyTransactionCount: 10,
+			},
+			nodeId: "1",
+			httpStatus:            http.StatusInternalServerError,
+			nodeRepoFindByIDError:             nil,
+			nodeRepoFindByIDReturns: &models.Node{
+				ID: "1",
+			},
+			nodeRepoFindByIDNumOfCalls:        1,
+			metricsRepoFindByIDError:          errors.New("not found"),
+			metricsRepoFindByIDNumOfCalls:     1,
+			metricsRepoSaveError: nil,
+			metricsRepoSaveNumOfCalls: 1,
+			nodeRepoAddNodeToActiveError: errors.New("fail to add repo"),
+			nodeRepoAddNodeToActiveNumOfCalls: 1,
 		},
 	}
 	for _, test := range tests {
@@ -62,30 +167,44 @@ func TestApiController_SaveMetricsHandler(t *testing.T) {
 			timestamp := time.Now()
 
 			// create mock controller
-			nodeRepoMock := mocks.NodeRepository{}
 			pingRepoMock := mocks.PingRepository{}
-			metricsRepoMock := mocks.MetricsRepository{}
 			recordRepoMock := mocks.RecordRepository{}
+			
+			nodeRepoMock := mocks.NodeRepository{}
+			nodeRepoMock.On("FindByID", test.nodeId).Return(
+				test.nodeRepoFindByIDReturns, test.nodeRepoFindByIDError, 
+			)
+			nodeRepoMock.On("AddNodeToActive", mock.Anything).Return(
+				test.nodeRepoAddNodeToActiveError,
+			)
+			
+			metricsRepoMock := mocks.MetricsRepository{}
+			// always return first value as nil, this value is not used in tested handler
+			metricsRepoMock.On("FindByID", test.nodeId).Return(
+				nil, test.metricsRepoFindByIDError,
+			)
 			metricsRepoMock.On("Save", &models.Metrics{
-				NodeId:                "1",
+				NodeId:                test.nodeId,
 				PeerCount:             10,
 				BestBlockHeight:       100,
 				FinalizedBlockHeight:  100,
 				ReadyTransactionCount: 10,
-			}).Return(test.repoReturn)
+			}).Return(test.metricsRepoSaveError)
+			
 			apiController := NewApiController(false, repositories.Repos{
 				NodeRepo:    &nodeRepoMock,
 				PingRepo:    &pingRepoMock,
 				MetricsRepo: &metricsRepoMock,
 				RecordRepo:  &recordRepoMock,
 			}, nil)
+			
 			handler := http.HandlerFunc(apiController.SaveMetricsHandler)
 
 			// create test request
 			rb, _ := json.Marshal(test.metricsRequest)
 			req, _ := http.NewRequest("POST", "/api/v1/metrics", bytes.NewReader(rb))
 			c := &auth.RequestContext{
-				NodeId:    "1",
+				NodeId:    test.nodeId,
 				Timestamp: timestamp,
 			}
 			ctx := context.WithValue(req.Context(), auth.RequestContextKey, c)
@@ -97,7 +216,11 @@ func TestApiController_SaveMetricsHandler(t *testing.T) {
 
 			// asserts
 			assert.Equal(t, test.httpStatus, rr.Code, fmt.Sprintf("Response status code should be %d", test.httpStatus))
-			assert.True(t, metricsRepoMock.AssertNumberOfCalls(t, "Save", test.numberOfRepoSaveCalls))
+			
+			nodeRepoMock.AssertNumberOfCalls(t, "FindByID", test.nodeRepoFindByIDNumOfCalls)
+			nodeRepoMock.AssertNumberOfCalls(t, "AddNodeToActive", test.nodeRepoAddNodeToActiveNumOfCalls)
+			metricsRepoMock.AssertNumberOfCalls(t, "Save", test.metricsRepoSaveNumOfCalls)
+			metricsRepoMock.AssertNumberOfCalls(t, "FindByID", test.metricsRepoFindByIDNumOfCalls)
 		})
 	}
 }

--- a/internal/repositories/metrics.go
+++ b/internal/repositories/metrics.go
@@ -8,6 +8,7 @@ import (
 type MetricsRepository interface {
 	FindByID(ID string) (*models.Metrics, error)
 	Save(metrics *models.Metrics) error
+	SaveAndCheckIfFirstEntry(metrics *models.Metrics) (bool, error)
 	GetAll() (*[]models.Metrics, error)
 	GetLatestBlockMetrics() (*models.LatestBlockMetrics, error)
 }
@@ -30,6 +31,21 @@ func (r *metricsRepo) FindByID(ID string) (*models.Metrics, error) {
 
 func (r *metricsRepo) Save(metrics *models.Metrics) error {
 	return r.db.Save(metrics)
+}
+
+func (r *metricsRepo) SaveAndCheckIfFirstEntry(metrics *models.Metrics) (bool, error) {
+	_, err := r.FindByID(metrics.NodeId)
+	isFirstMetricEntry := false
+	if err != nil {
+		if err.Error() == "not found" {
+			isFirstMetricEntry = true
+		} else {
+			return false, err
+		}
+	}
+
+	err = r.Save(metrics)
+	return isFirstMetricEntry, err
 }
 
 func (r metricsRepo) GetAll() (*[]models.Metrics, error) {

--- a/internal/repositories/node.go
+++ b/internal/repositories/node.go
@@ -73,11 +73,6 @@ func (r *nodeRepo) Save(node *models.Node) error {
 	if err != nil {
 		return err
 	}
-
-	err = r.AddNodeToActive(*node)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/mocks/repositories/MetricsRepository.go
+++ b/mocks/repositories/MetricsRepository.go
@@ -92,3 +92,24 @@ func (_m *MetricsRepository) Save(metrics *models.Metrics) error {
 
 	return r0
 }
+
+// SaveAndCheckIfFirstEntry provides a mock function with given fields: metrics
+func (_m *MetricsRepository) SaveAndCheckIfFirstEntry(metrics *models.Metrics) (bool, error) {
+	ret := _m.Called(metrics)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(*models.Metrics) bool); ok {
+		r0 = rf(metrics)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*models.Metrics) error); ok {
+		r1 = rf(metrics)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide all required information
-->

**Refactor when nodes are added to active. Remove adding to active from `NodeRepo.Save`. 
Now there are 2 ways for a node to be added to the active nodes:**

**1) on the first metrics entry that is sent node will be added to active nodes**
**2) when the node is penalized, reoccurring check if the node is reactivated can add the node to active nodes (`ScheduleCheckForPenalizedNode`)**
<!-- e.g. Refactored auth logic as part of the transition to OAuth -->

### PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have run linter localy
- [x] I have run unit and integration tests locally
- [x] Rebased to master branch / merged master
- [x] Updated CHANGELOG.md

### Changes
<!-- Please describe all changes made to codebase. -->
- Remove adding node to active from `NodeRepo.Save`
- Refactor `SaveMetricsHandler` to add node to active if it is first metrics entry being saved + expand tests

<!-- ### Example -->
<!-- You can add screenshots or videos to show changed behaviour -->

### Issues
<!-- Use GitHub keyword to close issues that are related to this PR -->

<!-- [REQUIRED] -->
Closes #81 
