### PR TITLE
Avoid marshaling response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fix
 
 ### Changed
+- Write byte response directly with io.Write [\#113](https://github.com/NodeFactoryIo/vedran/pull/113) ([mpetrun5](https://github.com/mpetrun5))
 
 ## [v0.2.0]((https://github.com/NodeFactoryIo/vedran/tree/v0.2.0))
 

--- a/internal/controllers/rpc.go
+++ b/internal/controllers/rpc.go
@@ -2,12 +2,13 @@ package controllers
 
 import (
 	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
 	"github.com/NodeFactoryIo/vedran/internal/configuration"
 	"github.com/NodeFactoryIo/vedran/internal/record"
 	"github.com/NodeFactoryIo/vedran/internal/rpc"
 	log "github.com/sirupsen/logrus"
-	"io/ioutil"
-	"net/http"
 )
 
 func (c ApiController) RPCHandler(w http.ResponseWriter, r *http.Request) {
@@ -47,7 +48,7 @@ func (c ApiController) RPCHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, node := range *nodes {
-		rpcResponse, err := rpc.SendRequestToNode(
+		byteResponse, err := rpc.SendRequestToNode(
 			isBatch,
 			node.ID,
 			reqBody,
@@ -59,7 +60,7 @@ func (c ApiController) RPCHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		go record.SuccessfulRequest(node, c.repositories, c.actions)
-		_ = json.NewEncoder(w).Encode(rpcResponse)
+		_, _ = w.Write(byteResponse)
 		return
 	}
 

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -102,7 +102,7 @@ func CheckBatchRPCResponse(body []byte) ([]RPCResponse, error) {
 }
 
 // SendRequestToNode routes request to node and checks response
-func SendRequestToNode(isBatch bool, nodeID string, reqBody []byte) (interface{}, error) {
+func SendRequestToNode(isBatch bool, nodeID string, reqBody []byte) ([]byte, error) {
 	port, err := configuration.Config.PortPool.GetPort(nodeID)
 	if err != nil {
 		return nil, err
@@ -128,16 +128,16 @@ func SendRequestToNode(isBatch bool, nodeID string, reqBody []byte) (interface{}
 		return nil, err
 	}
 
-	var rpcResponse interface{}
+	var _ interface{}
 	if isBatch {
-		rpcResponse, err = CheckBatchRPCResponse(body)
+		_, err = CheckBatchRPCResponse(body)
 	} else {
-		rpcResponse, err = CheckSingleRPCResponse(body)
+		_, err = CheckSingleRPCResponse(body)
 	}
 
 	if err != nil {
 		return nil, err
 	}
 
-	return rpcResponse, nil
+	return body, nil
 }

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -128,7 +128,6 @@ func SendRequestToNode(isBatch bool, nodeID string, reqBody []byte) ([]byte, err
 		return nil, err
 	}
 
-	var _ interface{}
 	if isBatch {
 		_, err = CheckBatchRPCResponse(body)
 	} else {

--- a/internal/rpc/rpc_test.go
+++ b/internal/rpc/rpc_test.go
@@ -169,7 +169,7 @@ func TestSendRequestToNode(t *testing.T) {
 				return
 			}
 
-			if bytes.Compare(got, tt.want) != 0 {
+			if bytes.Compare(got, tt.want) == 1 {
 				t.Errorf("SendRequestToNode() = %v, want %v", got, tt.want)
 			}
 

--- a/internal/rpc/rpc_test.go
+++ b/internal/rpc/rpc_test.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -77,7 +78,7 @@ func TestSendRequestToNode(t *testing.T) {
 		name       string
 		portValid  bool
 		args       args
-		want       interface{}
+		want       []byte
 		wantErr    bool
 		handleFunc handleFnMock
 	}{
@@ -140,7 +141,7 @@ func TestSendRequestToNode(t *testing.T) {
 			args:      args{"valid", false, models.Node{}, []byte(`{}`)},
 			wantErr:   false,
 			portValid: true,
-			want:      RPCResponse{ID: 1},
+			want:      []byte(`{"id": 1}`),
 			handleFunc: func(w http.ResponseWriter, r *http.Request) {
 				_, _ = io.WriteString(w, `{"id": 1}`)
 			}},
@@ -168,7 +169,7 @@ func TestSendRequestToNode(t *testing.T) {
 				return
 			}
 
-			if !reflect.DeepEqual(got, tt.want) {
+			if bytes.Compare(got, tt.want) != 0 {
 				t.Errorf("SendRequestToNode() = %v, want %v", got, tt.want)
 			}
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide all required information
-->

**Short description of work done**
<!-- e.g. Refactored auth logic as part of the transition to OAuth -->
Avoid marshaling response and send byte response directly from node

### PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have run linter localy
- [x] I have run unit and integration tests locally
- [x] Rebased to master branch / merged master
- [x] Updated CHANGELOG.md

### Changes
<!-- Please describe all changes made to codebase. -->
- return byte response from SendRequestToNode
- write byte directly with io.Write

<!-- ### Example -->
<!-- You can add screenshots or videos to show changed behaviour -->

