### PR TITLE
Use payout address to map stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Changed
 - Write byte response directly with io.Write [\#113](https://github.com/NodeFactoryIo/vedran/pull/113) ([mpetrun5](https://github.com/mpetrun5))
 - GetPort separated into GetHttpPort and GetWSPort [\#129](https://github.com/NodeFactoryIo/vedran/pull/129) ([mpetrun5](https://github.com/mpetrun5))
+- Use payout address to map stats [\#136](https://github.com/NodeFactoryIo/vedran/pull/136) ([MakMuftic](https://github.com/MakMuftic))
 
 ## [v0.2.0]((https://github.com/NodeFactoryIo/vedran/tree/v0.2.0))
 

--- a/internal/controllers/stats.go
+++ b/internal/controllers/stats.go
@@ -14,7 +14,7 @@ import (
 
 type StatsResponse struct {
 	Stats map[string]models.NodeStatsDetails `json:"stats"`
-	Fee   float32                             `json:"fee"`
+	Fee   float32                            `json:"fee"`
 }
 
 var getNow = time.Now

--- a/internal/controllers/stats.go
+++ b/internal/controllers/stats.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"encoding/json"
 	"github.com/NodeFactoryIo/vedran/internal/configuration"
+	"github.com/NodeFactoryIo/vedran/internal/models"
 	"github.com/NodeFactoryIo/vedran/internal/payout"
 	"github.com/NodeFactoryIo/vedran/internal/stats"
 	muxhelpper "github.com/gorilla/mux"
@@ -12,7 +13,7 @@ import (
 )
 
 type StatsResponse struct {
-	Stats map[string]payout.NodePayoutDetails `json:"stats"`
+	Stats map[string]models.NodeStatsDetails `json:"stats"`
 	Fee   float32                             `json:"fee"`
 }
 

--- a/internal/controllers/stats_test.go
+++ b/internal/controllers/stats_test.go
@@ -27,6 +27,7 @@ func TestApiController_StatisticsHandlerAllStats(t *testing.T) {
 		name       string
 		httpStatus int
 		nodeId     string
+		payoutAddress string
 		// NodeRepo.GetAll
 		nodeRepoGetAllReturns *[]models.Node
 		nodeRepoGetAllError   error
@@ -49,11 +50,13 @@ func TestApiController_StatisticsHandlerAllStats(t *testing.T) {
 		{
 			name:       "get valid stats",
 			nodeId:     "1",
+			payoutAddress: "0xtest-address",
 			httpStatus: http.StatusOK,
 			// NodeRepo.GetAll
 			nodeRepoGetAllReturns: &[]models.Node{
 				{
 					ID: "1",
+					PayoutAddress: "0xtest-address",
 				},
 			},
 			nodeRepoGetAllError: nil,
@@ -91,7 +94,7 @@ func TestApiController_StatisticsHandlerAllStats(t *testing.T) {
 			)
 			nodeRepoMock.On("FindByID", test.nodeId).Return(&models.Node{
 				ID:            test.nodeId,
-				PayoutAddress: "0xtest-address",
+				PayoutAddress: test.payoutAddress,
 			}, nil)
 			recordRepoMock := mocks.RecordRepository{}
 			recordRepoMock.On("FindSuccessfulRecordsInsideInterval",
@@ -143,9 +146,8 @@ func TestApiController_StatisticsHandlerAllStats(t *testing.T) {
 			var statsResponse StatsResponse
 			if rr.Code == http.StatusOK {
 				_ = json.Unmarshal(rr.Body.Bytes(), &statsResponse)
-				assert.LessOrEqual(t, test.nodeNumberOfPings, statsResponse.Stats[test.nodeId].Stats.TotalPings)
-				assert.Equal(t, test.nodeNumberOfRequests, statsResponse.Stats[test.nodeId].Stats.TotalRequests)
-				assert.Equal(t, "0xtest-address", statsResponse.Stats[test.nodeId].PayoutAddress)
+				assert.LessOrEqual(t, test.nodeNumberOfPings, statsResponse.Stats[test.payoutAddress].TotalPings)
+				assert.Equal(t, test.nodeNumberOfRequests, statsResponse.Stats[test.payoutAddress].TotalRequests)
 			}
 		})
 	}

--- a/internal/payout/distribution.go
+++ b/internal/payout/distribution.go
@@ -35,7 +35,7 @@ func CalculatePayoutDistributionByNode(
 	totalDistributedRequestsRewards := float64(0)
 	payoutAmountDistributionByNodes := make(map[string]big.Int, len(payoutDetails))
 
-	for nodeId, nodeStatsDetails := range payoutDetails {
+	for nodeAddress, nodeStatsDetails := range payoutDetails {
 		// liveliness rewards
 		livelinessReward := float64(0)
 		if totalNumberOfPings != 0 && nodeStatsDetails.TotalPings != 0 {
@@ -55,7 +55,7 @@ func CalculatePayoutDistributionByNode(
 
 		totalNodeReward := livelinessReward + requestsReward
 		totalNodeRewardAsInt, _ := big.NewFloat(totalNodeReward).Int(nil)
-		payoutAmountDistributionByNodes[nodeId] = *totalNodeRewardAsInt
+		payoutAmountDistributionByNodes[nodeAddress] = *totalNodeRewardAsInt
 	}
 
 	return payoutAmountDistributionByNodes

--- a/internal/payout/distribution_test.go
+++ b/internal/payout/distribution_test.go
@@ -18,27 +18,27 @@ func Test_CalculatePayoutDistributionByNode(t *testing.T) {
 		{ // this test is set for 10/90 split between liveliness and requests
 			name: "test distribution",
 			payoutDetails: map[string]models.NodeStatsDetails{
-				"1": {
+				"0x1": {
 					TotalPings:    100,
 					TotalRequests: 10,
 				},
-				"2": {
+				"0x2": {
 					TotalPings:    100,
 					TotalRequests: 5,
 				},
-				"3": {
+				"0x3": {
 					TotalPings:    90,
 					TotalRequests: 10,
 				},
-				"4": {
+				"0x4": {
 					TotalPings:    90,
 					TotalRequests: 5,
 				},
-				"5": {
+				"0x5": {
 					TotalPings:    50,
 					TotalRequests: 2,
 				},
-				"6": {
+				"0x6": {
 					TotalPings:    40,
 					TotalRequests: 0,
 				},
@@ -46,12 +46,12 @@ func Test_CalculatePayoutDistributionByNode(t *testing.T) {
 			totalReward:     100000000,
 			loadBalancerFee: 0.1,
 			resultDistribution: map[string]big.Int{
-				"1": *big.NewInt(27227393), // 27227393.617021276 // 100P 10R
-				"2": *big.NewInt(14571143), // 14571143.617021276 // 100P 5R
-				"3": *big.NewInt(27035904), // 27035904.255319147 // 90P  10R
-				"4": *big.NewInt(14379654), // 14379654.25531915  // 90P  5R
-				"5": *big.NewInt(6019946),  // 6019946.808510638  // 50P  2R
-				"6": *big.NewInt(765957),   // 765957.4468085106  // 40P  0R
+				"0x1": *big.NewInt(27227393), // 27227393.617021276 // 100P 10R
+				"0x2": *big.NewInt(14571143), // 14571143.617021276 // 100P 5R
+				"0x3": *big.NewInt(27035904), // 27035904.255319147 // 90P  10R
+				"0x4": *big.NewInt(14379654), // 14379654.25531915  // 90P  5R
+				"0x5": *big.NewInt(6019946),  // 6019946.808510638  // 50P  2R
+				"0x6": *big.NewInt(765957),   // 765957.4468085106  // 40P  0R
 			},
 		},
 	}

--- a/internal/payout/payout.go
+++ b/internal/payout/payout.go
@@ -8,29 +8,14 @@ import (
 	"time"
 )
 
-type NodePayoutDetails struct {
-	Stats         models.NodeStatsDetails `json:"stats"`
-	PayoutAddress string                  `json:"payout_address"`
-}
-
 func GetStatsForPayout(
 	repos repositories.Repos,
 	intervalEnd time.Time,
 	recordPayout bool,
-) (map[string]NodePayoutDetails, error) {
-
+) (map[string]models.NodeStatsDetails, error) {
 	statistics, err := stats.CalculateStatisticsFromLastPayout(repos, intervalEnd)
 	if err != nil {
 		return nil, err
-	}
-
-	payoutStatistics := make(map[string]NodePayoutDetails, len(statistics))
-	for nodeId, statsDetails := range statistics {
-		node, _ := repos.NodeRepo.FindByID(nodeId)
-		payoutStatistics[nodeId] = NodePayoutDetails{
-			Stats:         statsDetails,
-			PayoutAddress: node.PayoutAddress,
-		}
 	}
 
 	if recordPayout {
@@ -44,5 +29,5 @@ func GetStatsForPayout(
 		}
 	}
 
-	return payoutStatistics, nil
+	return statistics, nil
 }

--- a/internal/payout/payout_test.go
+++ b/internal/payout/payout_test.go
@@ -40,7 +40,7 @@ func Test_GetStatsForPayout(t *testing.T) {
 		payoutRepoSaveError      error
 		payoutRepoSaveNumOfCalls int
 		// GetStatsForPayout
-		getStatsForPayoutReturns map[string]NodePayoutDetails
+		getStatsForPayoutReturns map[string]models.NodeStatsDetails
 		getStatsForPayoutError   error
 	}{
 		{
@@ -51,13 +51,14 @@ func Test_GetStatsForPayout(t *testing.T) {
 			nodeRepoGetAllReturns: &[]models.Node{
 				{
 					ID: "1",
+					PayoutAddress: "0xpayout-address-1",
 				},
 			},
 			nodeRepoGetAllError: nil,
 			// NodeRepo.FindByID
 			nodeRepoFindByIDReturns: &models.Node{
 				ID:            "1",
-				PayoutAddress: "0xpayout-address",
+				PayoutAddress: "0xpayout-address-1",
 			},
 			nodeRepoFindByIDError: nil,
 			// RecordRepo.FindSuccessfulRecordsInsideInterval
@@ -84,13 +85,10 @@ func Test_GetStatsForPayout(t *testing.T) {
 			payoutRepoSaveNumOfCalls: 1,
 			// GetStatsForPayout
 			getStatsForPayoutError: nil,
-			getStatsForPayoutReturns: map[string]NodePayoutDetails{
-				"1": {
-					Stats: models.NodeStatsDetails{
-						TotalPings:    17280,
-						TotalRequests: 3,
-					},
-					PayoutAddress: "0xpayout-address",
+			getStatsForPayoutReturns: map[string]models.NodeStatsDetails{
+				"0xpayout-address-1": {
+					TotalPings:    17280,
+					TotalRequests: 3,
 				},
 			},
 		},
@@ -102,13 +100,14 @@ func Test_GetStatsForPayout(t *testing.T) {
 			nodeRepoGetAllReturns: &[]models.Node{
 				{
 					ID: "1",
+					PayoutAddress: "0xpayout-address-1",
 				},
 			},
 			nodeRepoGetAllError: nil,
 			// NodeRepo.FindByID
 			nodeRepoFindByIDReturns: &models.Node{
 				ID:            "1",
-				PayoutAddress: "0xpayout-address",
+				PayoutAddress: "0xpayout-address-1",
 			},
 			nodeRepoFindByIDError: nil,
 			// RecordRepo.FindSuccessfulRecordsInsideInterval
@@ -135,13 +134,10 @@ func Test_GetStatsForPayout(t *testing.T) {
 			payoutRepoSaveNumOfCalls: 0,
 			// GetStatsForPayout
 			getStatsForPayoutError: nil,
-			getStatsForPayoutReturns: map[string]NodePayoutDetails{
-				"1": {
-					Stats: models.NodeStatsDetails{
-						TotalPings:    17280,
-						TotalRequests: 3,
-					},
-					PayoutAddress: "0xpayout-address",
+			getStatsForPayoutReturns: map[string]models.NodeStatsDetails{
+				"0xpayout-address-1": {
+					TotalPings:    17280,
+					TotalRequests: 3,
 				},
 			},
 		},
@@ -163,13 +159,14 @@ func Test_GetStatsForPayout(t *testing.T) {
 			nodeRepoGetAllReturns: &[]models.Node{
 				{
 					ID: "1",
+					PayoutAddress: "0xpayout-address-1",
 				},
 			},
 			nodeRepoGetAllError: nil,
 			// NodeRepo.FindByID
 			nodeRepoFindByIDReturns: &models.Node{
 				ID:            "1",
-				PayoutAddress: "0xpayout-address",
+				PayoutAddress: "0xpayout-address-1",
 			},
 			nodeRepoFindByIDError: nil,
 			// RecordRepo.FindSuccessfulRecordsInsideInterval

--- a/internal/script/payout.go
+++ b/internal/script/payout.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/NodeFactoryIo/vedran/internal/controllers"
-	"github.com/NodeFactoryIo/vedran/internal/models"
 	"github.com/NodeFactoryIo/vedran/internal/payout"
 	log "github.com/sirupsen/logrus"
 	"net/http"
@@ -14,20 +13,15 @@ import (
 var statsEndpoint, _ = url.Parse("/api/v1/stats")
 
 func ExecutePayout(secret string, totalReward float64, loadbalancerUrl *url.URL) error {
-	stats, err := fetchStatsFromEndpoint(loadbalancerUrl.ResolveReference(statsEndpoint))
+	response, err := fetchStatsFromEndpoint(loadbalancerUrl.ResolveReference(statsEndpoint))
 	if err != nil {
 		return fmt.Errorf("unable to fetch stats from loadbalancer, %v", err)
 	}
 
-	// calculate distribution
-	nodeStatsDetails := make(map[string]models.NodeStatsDetails, len(stats.Stats))
-	for nodeId, nodeStats := range stats.Stats {
-		nodeStatsDetails[nodeId] = nodeStats.Stats
-	}
 	distributionByNode := payout.CalculatePayoutDistributionByNode(
-		nodeStatsDetails,
+		response.Stats,
 		totalReward,
-		float64(stats.Fee),
+		float64(response.Fee),
 	)
 
 	// todo - call sending payout transactions

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CalculateStatisticsFromLastPayout calculates stats for all nodes for interval, that starts from last recorded payout
-// until now, as map[string]models.NodeStatsDetails where keys represent node id-s
+// until now, as map[string]models.NodeStatsDetails where keys represent node payout address
 func CalculateStatisticsFromLastPayout(repos repositories.Repos, intervalEnd time.Time) (map[string]models.NodeStatsDetails, error) {
 	intervalStart, err := GetIntervalFromLastPayout(repos)
 	if err != nil {

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -28,7 +28,7 @@ func CalculateNodeStatisticsFromLastPayout(repos repositories.Repos, nodeId stri
 }
 
 // CalculateStatisticsForInterval calculates stats for all nodes for interval, specified with arguments
-// intervalStart and intervalEnd, as map[string]models.NodeStatsDetails where keys represent node id-s
+// intervalStart and intervalEnd, as map[string]models.NodeStatsDetails where keys represent node payout address
 func CalculateStatisticsForInterval(
 	repos repositories.Repos,
 	intervalStart time.Time,
@@ -49,7 +49,7 @@ func CalculateStatisticsForInterval(
 		if err != nil {
 			return nil, err
 		}
-		allNodesStats[node.ID] = *nodeStats
+		allNodesStats[node.PayoutAddress] = *nodeStats
 	}
 
 	return allNodesStats, nil

--- a/internal/stats/stats_test.go
+++ b/internal/stats/stats_test.go
@@ -148,9 +148,13 @@ func Test_CalculateNodeStatisticsFromLastPayout(t *testing.T) {
 func Test_CalculateStatisticsFromLastPayout(t *testing.T) {
 	now := time.Now()
 
+	testNode := models.Node{
+		ID: "1",
+		PayoutAddress: "0xpayout-address-1",
+	}
+
 	tests := []struct {
 		name          string
-		nodeID        string
 		intervalStart time.Time
 		intervalEnd   time.Time
 		// NodeRepo.GetAll
@@ -179,15 +183,12 @@ func Test_CalculateStatisticsFromLastPayout(t *testing.T) {
 	}{
 		{
 			name:   "valid statistics with multiple records and no downtime",
-			nodeID: "1",
 			// interval of 24 hours
 			intervalStart: now.Add(-24 * time.Hour),
 			intervalEnd:   now,
 			// NodeRepo.GetAll
 			nodeRepoGetAllReturns: &[]models.Node{
-				{
-					ID: "1",
-				},
+				testNode,
 			},
 			nodeRepoGetAllError:      nil,
 			nodeRepoGetAllNumOfCalls: 1,
@@ -212,7 +213,7 @@ func Test_CalculateStatisticsFromLastPayout(t *testing.T) {
 			payoutRepoFindLatestPayoutNumOfCalls: 1,
 			// CalculateNodeStatisticsForInterval
 			calculateStatisticsFromLastPayoutReturns: map[string]models.NodeStatsDetails{
-				"1": {
+				testNode.PayoutAddress: {
 					TotalPings:    17280, // no downtime - max number of pings
 					TotalRequests: 0,
 				},
@@ -221,7 +222,6 @@ func Test_CalculateStatisticsFromLastPayout(t *testing.T) {
 		},
 		{
 			name:   "error on fetching latest payout",
-			nodeID: "1",
 			// interval of 24 hours
 			intervalStart: now.Add(-24 * time.Hour),
 			intervalEnd:   now,
@@ -244,21 +244,21 @@ func Test_CalculateStatisticsFromLastPayout(t *testing.T) {
 			)
 			recordRepoMock := mocks.RecordRepository{}
 			recordRepoMock.On("FindSuccessfulRecordsInsideInterval",
-				test.nodeID, test.intervalStart, test.intervalEnd,
+				testNode.ID, test.intervalStart, test.intervalEnd,
 			).Return(
 				test.recordRepoFindSuccessfulRecordsInsideIntervalReturns,
 				test.recordRepoFindSuccessfulRecordsInsideIntervalError,
 			)
 			downtimeRepoMock := mocks.DowntimeRepository{}
 			downtimeRepoMock.On("FindDowntimesInsideInterval",
-				test.nodeID, test.intervalStart, test.intervalEnd,
+				testNode.ID, test.intervalStart, test.intervalEnd,
 			).Return(
 				test.downtimeRepoFindDowntimesInsideIntervalReturns,
 				test.downtimeRepoFindDowntimesInsideIntervalError,
 			)
 			pingRepoMock := mocks.PingRepository{}
 			pingRepoMock.On("CalculateDowntime",
-				test.nodeID, test.intervalEnd,
+				testNode.ID, test.intervalEnd,
 			).Return(
 				time.Now(),
 				test.pingRepoCalculateDowntimeReturnDuration,
@@ -467,9 +467,13 @@ func Test_CalculateNodeStatisticsForInterval(t *testing.T) {
 func Test_CalculateStatisticsForInterval(t *testing.T) {
 	now := time.Now()
 
+	testNode := models.Node{
+		ID: "1",
+		PayoutAddress: "0xpayout-address-1",
+	}
+
 	tests := []struct {
 		name          string
-		nodeID        string
 		intervalStart time.Time
 		intervalEnd   time.Time
 		// NodeRepo.GetAll
@@ -494,25 +498,22 @@ func Test_CalculateStatisticsForInterval(t *testing.T) {
 	}{
 		{
 			name:   "valid statistics with multiple records and no downtime",
-			nodeID: "1",
 			// interval of 24 hours
 			intervalStart: now.Add(-24 * time.Hour),
 			intervalEnd:   now,
 			// NodeRepo.GetAll
 			nodeRepoGetAllReturns: &[]models.Node{
-				{
-					ID: "1",
-				},
+				testNode,
 			},
 			nodeRepoGetAllError:      nil,
 			nodeRepoGetAllNumOfCalls: 1,
 			// RecordRepo.FindByNodeID
 			recordRepoFindSuccessfulRecordsInsideIntervalReturns: []models.Record{
-				{ID: 1, NodeId: "1", Status: "successful", Timestamp: now.Add(-20 * time.Hour)},
-				{ID: 2, NodeId: "1", Status: "successful", Timestamp: now.Add(-18 * time.Hour)},
-				{ID: 3, NodeId: "1", Status: "successful", Timestamp: now.Add(-17 * time.Hour)},
-				{ID: 4, NodeId: "1", Status: "successful", Timestamp: now.Add(-15 * time.Hour)},
-				{ID: 5, NodeId: "1", Status: "successful", Timestamp: now.Add(-12 * time.Hour)},
+				{ID: 1, NodeId: testNode.ID, Status: "successful", Timestamp: now.Add(-20 * time.Hour)},
+				{ID: 2, NodeId: testNode.ID, Status: "successful", Timestamp: now.Add(-18 * time.Hour)},
+				{ID: 3, NodeId: testNode.ID, Status: "successful", Timestamp: now.Add(-17 * time.Hour)},
+				{ID: 4, NodeId: testNode.ID, Status: "successful", Timestamp: now.Add(-15 * time.Hour)},
+				{ID: 5, NodeId: testNode.ID, Status: "successful", Timestamp: now.Add(-12 * time.Hour)},
 			},
 			recordRepoFindSuccessfulRecordsInsideIntervalError:      nil,
 			recordRepoFindSuccessfulRecordsInsideIntervalNumOfCalls: 1,
@@ -526,7 +527,7 @@ func Test_CalculateStatisticsForInterval(t *testing.T) {
 			pingRepoCalculateDowntimeNumOfCalls:     1,
 			// CalculateNodeStatisticsForInterval
 			calculateStatisticsForIntervalReturns: map[string]models.NodeStatsDetails{
-				"1": {
+				testNode.PayoutAddress: {
 					TotalPings:    17280, // no downtime - max number of pings
 					TotalRequests: 5,
 				},
@@ -535,7 +536,6 @@ func Test_CalculateStatisticsForInterval(t *testing.T) {
 		},
 		{
 			name:   "get all nodes fails",
-			nodeID: "1",
 			// interval of 24 hours
 			intervalStart: now.Add(-24 * time.Hour),
 			intervalEnd:   now,
@@ -549,15 +549,12 @@ func Test_CalculateStatisticsForInterval(t *testing.T) {
 		},
 		{
 			name:   "calculating statistics for node fails",
-			nodeID: "1",
 			// interval of 24 hours
 			intervalStart: now.Add(-24 * time.Hour),
 			intervalEnd:   now,
 			// NodeRepo.GetAll
 			nodeRepoGetAllReturns: &[]models.Node{
-				{
-					ID: "1",
-				},
+				testNode,
 			},
 			nodeRepoGetAllError:      nil,
 			nodeRepoGetAllNumOfCalls: 1,
@@ -580,21 +577,21 @@ func Test_CalculateStatisticsForInterval(t *testing.T) {
 			)
 			recordRepoMock := mocks.RecordRepository{}
 			recordRepoMock.On("FindSuccessfulRecordsInsideInterval",
-				test.nodeID, test.intervalStart, test.intervalEnd,
+				testNode.ID, test.intervalStart, test.intervalEnd,
 			).Return(
 				test.recordRepoFindSuccessfulRecordsInsideIntervalReturns,
 				test.recordRepoFindSuccessfulRecordsInsideIntervalError,
 			)
 			downtimeRepoMock := mocks.DowntimeRepository{}
 			downtimeRepoMock.On("FindDowntimesInsideInterval",
-				test.nodeID, test.intervalStart, test.intervalEnd,
+				testNode.ID, test.intervalStart, test.intervalEnd,
 			).Return(
 				test.downtimeRepoFindDowntimesInsideIntervalReturns,
 				test.downtimeRepoFindDowntimesInsideIntervalError,
 			)
 			pingRepoMock := mocks.PingRepository{}
 			pingRepoMock.On("CalculateDowntime",
-				test.nodeID, test.intervalEnd,
+				testNode.ID, test.intervalEnd,
 			).Return(
 				time.Now(),
 				test.pingRepoCalculateDowntimeReturnDuration,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide all required information
-->

**Replaced node ID with node payout address when mapping node stats**
<!-- e.g. Refactored auth logic as part of the transition to OAuth -->

### PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have run linter localy
- [x] I have run unit and integration tests locally
- [x] Rebased to dev branch / merged dev
- [x] Updated CHANGELOG.md

### Changes
<!-- Please describe all changes made to codebase. -->
- refactor stats controller + refactor unit tests
- refactor stats collecting functions (inside `/internal/stats` package) so they map stats on payout addresses + refactor unit tests

### Example
<!-- You can add screenshots or videos to show changed behaviour -->
Here is a sample response from `/api/v1/stats` endpoint:
```json
{
    "stats": {
        "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty": {
            "total_pings": 2630.7830677516004,
            "total_requests": 50
        }
    },
    "fee": 0.1
}
```

### Issues
<!-- Use github keyword to close issues that are related to this PR -->

<!-- [REQUIRED] -->
Closes #135
