### PR TITLE
Refactor payment interval calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Write byte response directly with io.Write [\#113](https://github.com/NodeFactoryIo/vedran/pull/113) ([mpetrun5](https://github.com/mpetrun5))
 - GetPort separated into GetHttpPort and GetWSPort [\#129](https://github.com/NodeFactoryIo/vedran/pull/129) ([mpetrun5](https://github.com/mpetrun5))
 - Use payout address to map stats [\#136](https://github.com/NodeFactoryIo/vedran/pull/136) ([MakMuftic](https://github.com/MakMuftic))
+- Refactor payment interval calculation [\#144](https://github.com/NodeFactoryIo/vedran/pull/144) ([MakMuftic](https://github.com/MakMuftic))
 
 ## [v0.2.0]((https://github.com/NodeFactoryIo/vedran/tree/v0.2.0))
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -274,23 +274,32 @@ func startCommand(_ *cobra.Command, _ []string) {
 	}
 	log.Debugf("Whitelisting set to: %t", whitelistEnabled)
 
+	var payoutConfiguration *schedulepayout.PayoutConfiguration
 	if !autoPayoutDisabled {
 		lbUrl, _ := url.Parse("http://" + publicIP + ":" + string(serverPort))
-		schedulepayout.StartScheduledPayout(payoutNumberOfDays, payoutPrivateKey, payoutTotalRewardAsFloat64, lbUrl)
+		payoutConfiguration = &schedulepayout.PayoutConfiguration{
+			PayoutNumberOfDays: int(payoutNumberOfDays),
+			PayoutTotalReward:  payoutTotalRewardAsFloat64,
+			LbURL:              lbUrl,
+		}
 	}
 
 	tunnel.StartHttpTunnelServer(tunnelServerPort, pPool)
-	loadbalancer.StartLoadBalancerServer(configuration.Configuration{
-		AuthSecret:          authSecret,
-		Name:                name,
-		CertFile:            certFile,
-		KeyFile:             keyFile,
-		Capacity:            capacity,
-		Fee:                 fee,
-		Selection:           selection,
-		Port:                serverPort,
-		TunnelServerAddress: tunnelServerAddress,
-		PortPool:            pPool,
-		WhitelistEnabled:    whitelistEnabled,
-	}, privateKey)
+	loadbalancer.StartLoadBalancerServer(
+		configuration.Configuration{
+			AuthSecret:          authSecret,
+			Name:                name,
+			CertFile:            certFile,
+			KeyFile:             keyFile,
+			Capacity:            capacity,
+			Fee:                 fee,
+			Selection:           selection,
+			Port:                serverPort,
+			TunnelServerAddress: tunnelServerAddress,
+			PortPool:            pPool,
+			WhitelistEnabled:    whitelistEnabled,
+		},
+		payoutConfiguration,
+		privateKey,
+	)
 }

--- a/internal/loadbalancer/server.go
+++ b/internal/loadbalancer/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/NodeFactoryIo/vedran/internal/repositories"
 	"github.com/NodeFactoryIo/vedran/internal/router"
 	"github.com/NodeFactoryIo/vedran/internal/schedule/checkactive"
+	schedulepayout "github.com/NodeFactoryIo/vedran/internal/schedule/payout"
 	"github.com/NodeFactoryIo/vedran/internal/schedule/penalize"
 	"github.com/asdine/storm/v3"
 	log "github.com/sirupsen/logrus"
@@ -17,7 +18,11 @@ import (
 	"time"
 )
 
-func StartLoadBalancerServer(props configuration.Configuration, privateKey string) {
+func StartLoadBalancerServer(
+	props configuration.Configuration,
+	payoutConfiguration *schedulepayout.PayoutConfiguration,
+	privateKey string,
+) {
 	configuration.Config = props
 
 	// set auth secret
@@ -74,6 +79,14 @@ func StartLoadBalancerServer(props configuration.Configuration, privateKey strin
 
 	// starts task that checks active nodes
 	checkactive.StartScheduledTask(repos)
+
+	// start scheduled payout if auto payout enabled
+	if payoutConfiguration != nil {
+		schedulepayout.StartScheduledPayout(
+			*payoutConfiguration,
+			privateKey,
+			*repos)
+	}
 
 	// start server
 	log.Infof("Starting vedran load balancer on port :%d...", props.Port)

--- a/internal/schedule/payout/payout.go
+++ b/internal/schedule/payout/payout.go
@@ -1,6 +1,7 @@
 package schedulepayout
 
 import (
+	"github.com/NodeFactoryIo/vedran/internal/repositories"
 	"github.com/NodeFactoryIo/vedran/internal/script"
 	"github.com/NodeFactoryIo/vedran/internal/ui"
 	log "github.com/sirupsen/logrus"
@@ -8,8 +9,15 @@ import (
 	"time"
 )
 
-func StartScheduledPayout(intervalInDays int32, secret string, reward float64, loadBalancerUrl *url.URL) {
-	ticker := time.NewTicker(time.Hour * time.Duration(24*intervalInDays))
+type PayoutConfiguration struct {
+	PayoutNumberOfDays int
+	PayoutTotalReward float64
+	LbURL *url.URL
+}
+
+// StartScheduledPayout checks every 24 hours
+func StartScheduledPayout(configuration PayoutConfiguration, privateKey string, repos repositories.Repos) {
+	ticker := time.NewTicker(time.Hour * 24)
 	done := make(chan bool)
 
 	go func() {
@@ -18,13 +26,37 @@ func StartScheduledPayout(intervalInDays int32, secret string, reward float64, l
 			case <-done:
 				return
 			case <-ticker.C:
-				scheduledPayout(secret, reward, loadBalancerUrl)
+				checkForPayout(
+					configuration.PayoutNumberOfDays,
+					privateKey,
+					configuration.PayoutTotalReward,
+					configuration.LbURL,
+					repos,
+				)
 			}
 		}
 	}()
 }
 
-func scheduledPayout(secret string, reward float64, loadBalancerUrl *url.URL) {
+func checkForPayout(intervalInDays int, secret string, reward float64, loadBalancerUrl *url.URL, repos repositories.Repos) {
+	daysSinceLastPayout, lastPayoutTimestamp, err := numOfDaysSinceLastPayout(repos)
+	if err != nil {
+		log.Error("Unable to calculate number of days since last payout")
+		return
+	}
+
+	if daysSinceLastPayout >= intervalInDays {
+		go startPayout(secret, reward, loadBalancerUrl)
+	} else {
+		log.Infof(
+			"Last payout was %s, next payout will be in %d days",
+			lastPayoutTimestamp.Format("2006-January-02"),
+			daysSinceLastPayout,
+		)
+	}
+}
+
+func startPayout(secret string, reward float64, loadBalancerUrl *url.URL)  {
 	log.Info("Starting automatic payout...")
 	transactionDetails, err := script.ExecutePayout(secret, reward, loadBalancerUrl)
 	if transactionDetails != nil {
@@ -37,4 +69,14 @@ func scheduledPayout(secret string, reward float64, loadBalancerUrl *url.URL) {
 	} else {
 		log.Info("Payout execution finished")
 	}
+}
+
+func numOfDaysSinceLastPayout(repos repositories.Repos) (int, *time.Time, error) {
+	latestPayout, err := repos.PayoutRepo.FindLatestPayout()
+	if err != nil {
+		log.Error("")
+		return 0, nil, err
+	}
+	daysSinceLastPayout := time.Now().Sub(latestPayout.Timestamp) / (24 * time.Hour)
+	return int(daysSinceLastPayout), &latestPayout.Timestamp, nil
 }

--- a/internal/schedule/payout/payout.go
+++ b/internal/schedule/payout/payout.go
@@ -77,6 +77,6 @@ func numOfDaysSinceLastPayout(repos repositories.Repos) (int, *time.Time, error)
 	if err != nil {
 		return 0, nil, err
 	}
-	daysSinceLastPayout := time.Now().Sub(latestPayout.Timestamp) / (24 * time.Hour)
+	daysSinceLastPayout := time.Since(latestPayout.Timestamp) / (24 * time.Hour)
 	return int(daysSinceLastPayout), &latestPayout.Timestamp, nil
 }

--- a/internal/schedule/payout/payout.go
+++ b/internal/schedule/payout/payout.go
@@ -15,7 +15,8 @@ type PayoutConfiguration struct {
 	LbURL *url.URL
 }
 
-// StartScheduledPayout checks every 24 hours
+// StartScheduledPayout checks every 24 hours how many days have passed since last payout.
+// If number of passed days is equal or bigger than defined interval in configuration, start automatic payout
 func StartScheduledPayout(configuration PayoutConfiguration, privateKey string, repos repositories.Repos) {
 	ticker := time.NewTicker(time.Hour * 24)
 	done := make(chan bool)

--- a/internal/schedule/payout/payout_test.go
+++ b/internal/schedule/payout/payout_test.go
@@ -1,0 +1,90 @@
+package schedulepayout
+
+import (
+	"errors"
+	"github.com/NodeFactoryIo/vedran/internal/models"
+	"github.com/NodeFactoryIo/vedran/internal/repositories"
+	mocks "github.com/NodeFactoryIo/vedran/mocks/repositories"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+var (
+	timestampSince20days = time.Now().Add(-20 * (24 * time.Hour))
+	timestampSince2days = time.Now().Add(-2 * (24 * time.Hour))
+	timestampSince2hours = time.Now().Add(-2 * time.Hour)
+)
+
+func Test_numOfDaysSinceLastPayout(t *testing.T) {
+	tests := []struct {
+		name string
+		latestPayout *models.Payout
+		latestPayoutError error
+		numOfDaysSinceLastPayoutError error
+		numOfDaysSinceLastPayoutNumOfDays int
+		numOfDaysSinceLastPayoutTimestamp *time.Time
+	}{
+		{
+			name: "last payout before 20 days",
+			latestPayout: &models.Payout{
+				ID:             "",
+				Timestamp:      timestampSince20days,
+				PaymentDetails: nil,
+			},
+			latestPayoutError: nil,
+			numOfDaysSinceLastPayoutError: nil,
+			numOfDaysSinceLastPayoutNumOfDays: 20,
+			numOfDaysSinceLastPayoutTimestamp: &timestampSince20days,
+		},
+		{
+			name: "last payout before 2 days",
+			latestPayout: &models.Payout{
+				ID:             "",
+				Timestamp:      timestampSince2days,
+				PaymentDetails: nil,
+			},
+			latestPayoutError: nil,
+			numOfDaysSinceLastPayoutError: nil,
+			numOfDaysSinceLastPayoutNumOfDays: 2,
+			numOfDaysSinceLastPayoutTimestamp: &timestampSince2days,
+		},
+		{
+			name: "last payout before 2 hours",
+			latestPayout: &models.Payout{
+				ID:             "",
+				Timestamp:      timestampSince2hours,
+				PaymentDetails: nil,
+			},
+			latestPayoutError: nil,
+			numOfDaysSinceLastPayoutError: nil,
+			numOfDaysSinceLastPayoutNumOfDays: 0,
+			numOfDaysSinceLastPayoutTimestamp: &timestampSince2hours,
+		},
+		{
+			name: "error on latest payout",
+			latestPayout: nil,
+			latestPayoutError: errors.New("db error"),
+			numOfDaysSinceLastPayoutError: errors.New("db error"),
+			numOfDaysSinceLastPayoutNumOfDays: 0,
+			numOfDaysSinceLastPayoutTimestamp: nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			payoutRepoMock := mocks.PayoutRepository{}
+			payoutRepoMock.On("FindLatestPayout").Return(
+				test.latestPayout, test.latestPayoutError,
+			)
+			repos := repositories.Repos{
+				PayoutRepo: &payoutRepoMock,
+			}
+
+			daysSinceLastPayout, lastPayoutTimestamp, err := numOfDaysSinceLastPayout(repos)
+			assert.Equal(t, test.latestPayoutError, err)
+			assert.Equal(t, test.numOfDaysSinceLastPayoutNumOfDays, daysSinceLastPayout)
+			assert.Equal(t, test.numOfDaysSinceLastPayoutTimestamp, lastPayoutTimestamp)
+		})
+	}
+}
+


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide all required information
-->

**Refactored automatic payout so every 24h it is checked if enough days have passed since the last payout to start a new one**
<!-- e.g. Refactored auth logic as part of the transition to OAuth -->

@mpetrunic here I added daily log with info on next payout, here is a relevant snip:
```go
if daysSinceLastPayout >= intervalInDays {
	go startPayout(privateKey, reward, loadBalancerUrl)
} else {
	log.Infof(
		"Last payout was %s, next payout will be in %d days",
		lastPayoutTimestamp.Format("2006-January-02"),
		intervalInDays - daysSinceLastPayout,
	)
}
```

### PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have run linter localy
- [x] I have run unit and integration tests locally
- [x] Rebased to master branch / merged master
- [x] Updated CHANGELOG.md

### Changes
<!-- Please describe all changes made to codebase. -->
- refactored scheduled task for automatic payout
- move starting scheduled payout to lb server startup function

<!-- ### Example -->
<!-- You can add screenshots or videos to show changed behaviour -->

### Issues
<!-- Use github keyword to close issues that are related to this PR -->

<!-- [REQUIRED] -->
Closes #139 
