### PR TITLE
Add buffer for target block metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [unreleased]((https://github.com/NodeFactoryIo/vedran/tree/HEAD))
 [Full Changelog](https://github.com/NodeFactoryIo/vedran/compare/v0.5.0...HEAD)
 
+### Added
+
+### Fix
+- Add buffer for target block metric [\#184](https://github.com/NodeFactoryIo/vedran/pull/184) ([MakMuftic](https://github.com/MakMuftic))
+
+### Changed
 
 ## [v0.5.0]((https://github.com/NodeFactoryIo/vedran/tree/v0.5.0))
 [Full Changelog](https://github.com/NodeFactoryIo/vedran/compare/v0.4.3...v0.5.0)

--- a/internal/active/active.go
+++ b/internal/active/active.go
@@ -10,7 +10,7 @@ import (
 const (
 	IntervalFromLastPing = 10 * time.Second
 	AllowedBlocksBehind  = 10
-	TargetBlockBuffer	 = 10
+	TargetBlockBuffer    = 10
 )
 
 // CheckIfNodeActive checks if nodes last recorded ping is in last IntervalFromLastPing and if nodes last recorded
@@ -60,11 +60,12 @@ func CheckIfMetricsValid(nodeID string, repos *repositories.Repos) (bool, error)
 		)
 		return false, nil
 	}
-
+	// get best metrics from pool of nodes
 	latestBlockMetrics, err := repos.MetricsRepo.GetLatestBlockMetrics()
 	if err != nil {
 		return false, err
 	}
+	// check if node falling behind
 	if metrics.BestBlockHeight <= (latestBlockMetrics.BestBlockHeight-AllowedBlocksBehind) ||
 		metrics.FinalizedBlockHeight <= (latestBlockMetrics.FinalizedBlockHeight-AllowedBlocksBehind) {
 		log.Debugf(
@@ -77,7 +78,6 @@ func CheckIfMetricsValid(nodeID string, repos *repositories.Repos) (bool, error)
 		)
 		return false, nil
 	}
-
 	return true, nil
 }
 

--- a/internal/active/active.go
+++ b/internal/active/active.go
@@ -10,6 +10,7 @@ import (
 const (
 	IntervalFromLastPing = 10 * time.Second
 	AllowedBlocksBehind  = 10
+	TargetBlockBuffer	 = 10
 )
 
 // CheckIfNodeActive checks if nodes last recorded ping is in last IntervalFromLastPing and if nodes last recorded
@@ -52,7 +53,7 @@ func CheckIfMetricsValid(nodeID string, repos *repositories.Repos) (bool, error)
 		return false, err
 	}
 	// check if node synced
-	if metrics.BestBlockHeight != metrics.TargetBlockHeight {
+	if (metrics.BestBlockHeight + TargetBlockBuffer) < metrics.TargetBlockHeight {
 		log.Debugf(
 			"Node %s not synced. Best block: %d, Target block: %d",
 			nodeID, metrics.BestBlockHeight, metrics.TargetBlockHeight,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide all required information
-->

**Add buffer when checking if the node is synched (is the best block same as target block)**
<!-- e.g. Refactored auth logic as part of the transition to OAuth -->

@mpetrun5 @mpetrunic I set this buffer to be 10 blocks, same as `AllowedBlockBehind` buffer but maybe I can reduce it to 5 as here it should only be a lag of 1 to 2 blocks at most.

### PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have run linter localy
- [x] I have run unit and integration tests locally
- [x] Rebased to master branch / merged master
- [x] Updated CHANGELOG.md

### Changes
<!-- Please describe all changes made to codebase. -->
- Add buffer when checking if the node is synched

### Issues
<!-- Use github keyword to close issues that are related to this PR -->

<!-- [REQUIRED] -->
Closes #183 
