### PR TITLE
Ping handling upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [unreleased]((https://github.com/NodeFactoryIo/vedran/tree/HEAD))
+[Full Changelog](https://github.com/NodeFactoryIo/vedran/compare/v0.5.3...HEAD)
+
+### Added
+
+### Fix
+
+### Changed
+- Ping handling upgrade [\#198](https://github.com/NodeFactoryIo/vedran/pull/198) ([MakMuftic](https://github.com/MakMuftic))
+
 ## [v0.5.3]((https://github.com/NodeFactoryIo/vedran/tree/HEAD))
 [Full Changelog](https://github.com/NodeFactoryIo/vedran/compare/v0.5.2...HEAD)
 

--- a/internal/controllers/ping.go
+++ b/internal/controllers/ping.go
@@ -23,7 +23,7 @@ func (c ApiController) PingHandler(w http.ResponseWriter, r *http.Request) {
 	// if two pings come one after another (in 2 second interval)
 	// this means that one ping stuck in network and
 	// there is no need to write multiple downtimes
-	if request.Timestamp.Sub(lastPingTime).Seconds() > 2 {
+	if math.Abs(request.Timestamp.Sub(lastPingTime).Seconds()) > 2 {
 		// check if there were downtime
 		if math.Abs(downtimeDuration.Seconds()) > (stats.PingIntervalInSeconds + pingOffset) {
 			downtime := models.Downtime{

--- a/internal/schedule/checkactive/schedule.go
+++ b/internal/schedule/checkactive/schedule.go
@@ -34,7 +34,7 @@ func StartScheduledTask(repos *repositories.Repos) {
 func scheduledTask(repos *repositories.Repos, actions actions.Actions) {
 	log.Debug("Started task: check all active nodes")
 	activeNodes := repos.NodeRepo.GetAllActiveNodes()
-
+	var activeNodesAfterCheck []string
 	for _, node := range *activeNodes {
 
 		pingActive, err := active.CheckIfPingActive(node.ID, repos)
@@ -60,6 +60,14 @@ func scheduledTask(repos *repositories.Repos, actions actions.Actions) {
 				log.Errorf("Unable to remove node %s from active because of %v", node.ID, err)
 			}
 			log.Debugf("Node %s metrics lagging more than 10 blocks, removed node from active", node.ID)
+		} else {
+			activeNodesAfterCheck = append(activeNodesAfterCheck, node.ID)
 		}
+	}
+
+	if len(activeNodesAfterCheck) == 0 {
+		log.Debug("There is no active nodes currently")
+	} else {
+		log.Debugf("Currently active nodes: %v", activeNodesAfterCheck)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide all required information
-->

**Few minor changes to improve handling pings**
<!-- e.g. Refactored auth logic as part of the transition to OAuth -->

### PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have run linter localy
- [x] I have run unit and integration tests locally
- [x] Rebased to master branch / merged master
- [x] Updated CHANGELOG.md

### Changes
<!-- Please describe all changes made to codebase. -->
- Add check if two (or more) pings come one after other, this happens if one ping gets stuck in the network -> there is no need to add double downtime
- Expand buffer for pings, from 5 + 5 seconds to 5 + 8 seconds (we will monitor this further)
- Add additional logs for currently active nodes
